### PR TITLE
Add support for getting problems by tag

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -198,7 +198,7 @@ pub fn process() -> Result<()> {
         }
         Command::List(list) => {
             if list.tag.is_some() {
-                provider.list_tag_problems(list)?;
+                provider.list_problems_with_tag(list)?;
             } else {
                 provider.list_problems(list, None)?;
             }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -197,7 +197,11 @@ pub fn process() -> Result<()> {
             provider.pick_problem(pick)?;
         }
         Command::List(list) => {
-            provider.list_problems(list)?;
+            if list.tag.is_some() {
+                provider.list_tag_problems(list)?;
+            } else {
+                provider.list_problems(list, None)?;
+            }
         }
         Command::User(user) => {
             provider.process_auth(user)?;

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -309,7 +309,7 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
                    translatedName
                    slug
                    questions {
-                     questionId
+                     questionFrontendId
                    }
                  }
                }
@@ -332,7 +332,7 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
                 questions
                     .iter()
                     .map(|serde_string| {
-                        serde_json::from_value(serde_string["questionId"].clone()).unwrap()
+                        serde_json::from_value(serde_string["questionFrontendId"].clone()).unwrap()
                     })
                     .collect()
             });
@@ -362,7 +362,9 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
         if let Some(question_ids) = options.and_then(|options| options.question_ids) {
             probs = probs
                 .into_iter()
-                .filter(|question| question_ids.contains(&question.stat.question_id.to_string()))
+                .filter(|question| {
+                    question_ids.contains(&question.stat.frontend_question_id.to_string())
+                })
                 .collect();
         }
 

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -301,7 +301,7 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
         Ok(problems_res)
     }
 
-    fn list_tag_problems(&mut self, list: List) -> Result<()> {
+    fn list_problems_with_tag(&mut self, list: List) -> Result<()> {
         let query = r#"
             query getTopicTag($slug: String!) {
                  topicTag(slug: $slug) {

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -3,8 +3,8 @@ use crate::{
     cmd::{self, Command, List, OrderBy, Query, User},
     icon::Icon,
     service::{
-        self, auth, CacheKey, Comment, CommentStyle, Lang, LangInfo, Problem, ServiceProvider,
-        Session,
+        self, auth, CacheKey, Comment, CommentStyle, Lang, LangInfo, ListProblemsOptions, Problem,
+        ServiceProvider, Session,
     },
     template::{parse_code, InjectPosition, Pattern},
     Config, Either, InjectCode, LeetUpError, Result, Urls,
@@ -19,7 +19,7 @@ use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
@@ -301,10 +301,70 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
         Ok(problems_res)
     }
 
-    fn list_problems(&mut self, list: List) -> Result<()> {
+    fn list_tag_problems(&mut self, list: List) -> Result<()> {
+        let query = r#"
+            query getTopicTag($slug: String!) {
+                 topicTag(slug: $slug) {
+                   name
+                   translatedName
+                   slug
+                   questions {
+                     questionId
+                   }
+                 }
+               }
+            "#;
+        let body: serde_json::value::Value = json!(
+        {
+          "operationName": "getTopicTag",
+          "variables": {
+            "slug": list.tag,
+          },
+          "query": query
+        }
+                );
+
+        let response = client::post(self, &self.config.urls.graphql, &body, || None)?;
+
+        let question_ids: Option<HashSet<_>> = response["data"]["topicTag"]["questions"]
+            .as_array()
+            .and_then(|questions| {
+                questions
+                    .iter()
+                    .map(|serde_string| {
+                        serde_json::from_value(serde_string["questionId"].clone()).unwrap()
+                    })
+                    .collect()
+            });
+
+        match question_ids {
+            Some(question_ids) if question_ids.len() != 0 => self.list_problems(
+                list,
+                Some(ListProblemsOptions {
+                    question_ids: Some(question_ids),
+                }),
+            ),
+            _ => {
+                println!(
+                    "{}",
+                    Color::Red(&format!("No problems were found for that tag!",)).make()
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn list_problems(&mut self, list: List, options: Option<ListProblemsOptions>) -> Result<()> {
         let problems_res = self.fetch_all_problems()?;
         let mut probs: Vec<StatStatusPair> =
             serde_json::from_value(problems_res["stat_status_pairs"].clone())?;
+
+        if let Some(question_ids) = options.and_then(|options| options.question_ids) {
+            probs = probs
+                .into_iter()
+                .filter(|question| question_ids.contains(&question.stat.question_id.to_string()))
+                .collect();
+        }
 
         if list.order.is_some() {
             let orders = OrderBy::from_str(list.order.as_ref().unwrap());

--- a/src/service/provider.rs
+++ b/src/service/provider.rs
@@ -21,7 +21,7 @@ pub trait ServiceProvider<'a> {
         list: cmd::List,
         options: Option<ListProblemsOptions>,
     ) -> Result<()>;
-    fn list_tag_problems(&mut self, list: cmd::List) -> Result<()>;
+    fn list_problems_with_tag(&mut self, list: cmd::List) -> Result<()>;
     fn pick_problem(&mut self, pick: cmd::Pick) -> Result<()>;
     fn problem_test(&self, test: cmd::Test) -> Result<()>;
     fn problem_submit(&self, submit: cmd::Submit) -> Result<()>;

--- a/src/service/provider.rs
+++ b/src/service/provider.rs
@@ -6,6 +6,7 @@ use crate::{
 use cookie::Cookie;
 use leetup_cache::kvstore::KvStore;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -15,13 +16,22 @@ pub trait ServiceProvider<'a> {
     fn session(&self) -> Option<&Session>;
     fn config(&self) -> Result<&Config>;
     fn fetch_all_problems(&mut self) -> Result<serde_json::value::Value>;
-    fn list_problems(&mut self, list: cmd::List) -> Result<()>;
+    fn list_problems(
+        &mut self,
+        list: cmd::List,
+        options: Option<ListProblemsOptions>,
+    ) -> Result<()>;
+    fn list_tag_problems(&mut self, list: cmd::List) -> Result<()>;
     fn pick_problem(&mut self, pick: cmd::Pick) -> Result<()>;
     fn problem_test(&self, test: cmd::Test) -> Result<()>;
     fn problem_submit(&self, submit: cmd::Submit) -> Result<()>;
     fn process_auth(&mut self, user: User) -> Result<()>;
     fn cache(&mut self) -> Result<&KvStore>;
     fn name(&self) -> &'a str;
+}
+
+pub struct ListProblemsOptions {
+    pub question_ids: Option<HashSet<String>>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
[Partial fix for #18](https://github.com/dragfire/leetup/issues/18)
* Added CLI `-t` option for tags which can be used as follows `leetup -t <TAG>` eg) `leetup -t array` 
* I just fetch all the question_ids associated to a tag, and then filter all the questions based on these ids
* If no results are found for tag, I just show some text that says there were no questions found for that tag
* I did not validate the input tag but this can also be done by fetching all the tags available and making sure input tag is one of them