### PR TITLE
Support stdin for test data command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/dragfire/leetup"
 repository = "https://github.com/dragfire/leetup"
 keywords = ["cli", "leetcode"]
 categories = ["command-line-utilities"]
+exclude = [
+  "assets/*"
+]
 
 [dependencies]
 leetup-cache = { path = "./cache", version = "0.1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leetup"
-version = "1.2.1"
+version = "1.2.3"
 authors = ["dragfire <asem.devajit@gmail.com>"]
 edition = "2018"
 description = "Leetcode cli"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -74,7 +74,7 @@ pub struct Test {
 
     /// Custom test cases.
     #[structopt(short)]
-    pub test_data: String,
+    pub test_data: Option<Option<String>>,
 }
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
Get string from command line if provided, otherwise try to get string from stdin
We can provide test data as multiline input using stdin.
# Example:
      
      leetup test 3sum.java -t << END
      [1,-1,0]
      [0, 1, 1, 1, 2, -3, -1]
      [1,2,3]
      END
    