### PR TITLE
Improve printer for execution results

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,17 @@ pub enum Either {
     String(String),
 }
 
+impl From<String> for Either {
+    fn from(s: String) -> Self {
+        let split: Vec<String> = s.trim().split("\n").map(|st| st.to_owned()).collect();
+        if split.is_empty() {
+            Either::String(s.to_owned())
+        } else {
+            Either::Sequence(split)
+        }
+    }
+}
+
 impl ToString for Either {
     fn to_string(&self) -> String {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use error::{LeetUpError, Result};
 pub mod cmd;
 mod config;
 mod error;
+mod printer;
 
 pub(crate) mod client;
 pub(crate) mod icon;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -207,9 +207,17 @@ pub struct CodeDefinition {
 
 #[derive(Deserialize, Debug)]
 pub struct SubmissionResult {
+    pub state: Option<String>,
+    pub input: Option<Either>,
+    pub input_formatted: Option<Either>,
     pub code_output: Option<Either>,
+    pub std_output: Option<Either>,
+    pub last_test_case: Option<Either>,
+    pub correct_answer: Option<bool>,
     pub code_answer: Option<Either>,
+    pub expected_output: Option<Either>,
     pub expected_code_output: Option<Either>,
+    pub expected_answer: Option<Either>,
     pub expected_code_answer: Option<Either>,
     pub compare_result: Option<String>,
     pub compile_error: Option<String>,
@@ -236,7 +244,10 @@ impl SubmissionResult {
     }
 
     pub fn has_runtime_error(&self) -> bool {
-        self.status_msg.to_lowercase().contains("error")
+        let tle = "time limit exceeded";
+        let msg = self.status_msg.to_lowercase();
+
+        msg.eq(tle) || msg.contains("error")
     }
 
     pub fn has_error(&self) -> bool {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -206,7 +206,7 @@ pub struct CodeDefinition {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct SubmissionResult {
+pub struct SubmissionResponse {
     pub state: Option<String>,
     pub input: Option<Either>,
     pub input_formatted: Option<Either>,
@@ -226,7 +226,6 @@ pub struct SubmissionResult {
     pub memory: Option<u32>,
     pub memory_percentile: Option<f32>,
     pub pretty_lang: String,
-    pub question_id: Option<u32>,
     pub run_success: bool,
     pub runtime_percentile: Option<f32>,
     pub expected_status_code: Option<u32>,
@@ -238,19 +237,31 @@ pub struct SubmissionResult {
     pub total_testcases: Option<u32>,
 }
 
-impl SubmissionResult {
-    pub fn has_compile_error(&self) -> bool {
+pub trait ExecutionErrorResponse {
+    fn has_compile_error(&self) -> bool;
+
+    fn has_runtime_error(&self) -> bool;
+
+    fn has_error(&self) -> bool;
+
+    fn is_error(&self) -> bool {
+        self.has_compile_error() || self.has_runtime_error() || self.has_error()
+    }
+}
+
+impl ExecutionErrorResponse for SubmissionResponse {
+    fn has_compile_error(&self) -> bool {
         self.compile_error.is_some() || self.full_compile_error.is_some()
     }
 
-    pub fn has_runtime_error(&self) -> bool {
+    fn has_runtime_error(&self) -> bool {
         let tle = "time limit exceeded";
         let msg = self.status_msg.to_lowercase();
 
         msg.eq(tle) || msg.contains("error")
     }
 
-    pub fn has_error(&self) -> bool {
+    fn has_error(&self) -> bool {
         self.total_correct.lt(&self.total_testcases)
     }
 }

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -1,6 +1,7 @@
 mod printer;
+mod submit_execution_printer;
 mod test_execution_printer;
 
 pub use printer::*;
+pub use submit_execution_printer::SubmitExecutionResult;
 pub use test_execution_printer::TestExecutionResult;
-

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -1,0 +1,6 @@
+mod printer;
+mod test_execution_printer;
+
+pub use printer::*;
+pub use test_execution_printer::TestExecutionResult;
+

--- a/src/printer/printer.rs
+++ b/src/printer/printer.rs
@@ -3,10 +3,6 @@ pub(crate) const TEXT_BOLD_ON: &'static str = "\x1b[1m";
 pub(crate) const TEXT_BOLD_OFF: &'static str = "\x1b[m";
 
 pub trait Printer: ExecutionResultPrinter {
-    fn bold_text(&self, s: &str) -> String {
-        format!("{}{}{}", s, TEXT_BOLD_ON, TEXT_BOLD_OFF)
-    }
-
     fn print(&self) {
         print!("{}", self.buffer());
     }
@@ -16,4 +12,12 @@ pub trait ExecutionResultPrinter {
     fn is_error(&self) -> bool;
 
     fn buffer(&self) -> String;
+}
+
+pub mod decorator {
+    use super::*;
+
+    pub fn bold_text(s: &str) -> String {
+        format!("{}{}{}", s, TEXT_BOLD_ON, TEXT_BOLD_OFF)
+    }
 }

--- a/src/printer/printer.rs
+++ b/src/printer/printer.rs
@@ -1,17 +1,25 @@
+use crate::model::SubmissionResponse;
+
 pub(crate) const NEW_LINE: &'static str = "\n";
 pub(crate) const TEXT_BOLD_ON: &'static str = "\x1b[1m";
 pub(crate) const TEXT_BOLD_OFF: &'static str = "\x1b[m";
 
-pub trait Printer: ExecutionResultPrinter {
+pub trait Printer {
     fn print(&self) {
         print!("{}", self.buffer());
     }
-}
 
-pub trait ExecutionResultPrinter {
     fn is_error(&self) -> bool;
 
     fn buffer(&self) -> String;
+
+    fn total_cases_ratio_buffer(&self, response: &SubmissionResponse) -> String {
+        format!(
+            "{}/{}",
+            response.total_correct.unwrap_or(0),
+            response.total_testcases.unwrap_or(0)
+        )
+    }
 }
 
 pub mod decorator {

--- a/src/printer/printer.rs
+++ b/src/printer/printer.rs
@@ -1,0 +1,19 @@
+pub(crate) const NEW_LINE: &'static str = "\n";
+pub(crate) const TEXT_BOLD_ON: &'static str = "\x1b[1m";
+pub(crate) const TEXT_BOLD_OFF: &'static str = "\x1b[m";
+
+pub trait Printer: ExecutionResultPrinter {
+    fn bold_text(&self, s: &str) -> String {
+        format!("{}{}{}", s, TEXT_BOLD_ON, TEXT_BOLD_OFF)
+    }
+
+    fn print(&self) {
+        print!("{}", self.buffer());
+    }
+}
+
+pub trait ExecutionResultPrinter {
+    fn is_error(&self) -> bool;
+
+    fn buffer(&self) -> String;
+}

--- a/src/printer/submit_execution_printer.rs
+++ b/src/printer/submit_execution_printer.rs
@@ -1,0 +1,279 @@
+use colci::Color;
+
+use crate::model::ExecutionErrorResponse;
+use crate::printer::{decorator::bold_text, Printer, NEW_LINE};
+use crate::{icon::Icon, model::SubmissionResponse, Either};
+
+#[derive(Debug)]
+pub struct SubmitExecutionResult {
+    submission_response: SubmissionResponse,
+}
+
+impl Printer for SubmitExecutionResult {
+    fn is_error(&self) -> bool {
+        self.submission_response.is_error()
+    }
+
+    fn buffer(&self) -> String {
+        if self.is_error() {
+            self.error_buffer()
+        } else {
+            self.success_buffer()
+        }
+    }
+}
+
+impl SubmitExecutionResult {
+    pub fn new(submission_response: SubmissionResponse) -> Self {
+        Self {
+            submission_response,
+        }
+    }
+
+    fn error_buffer(&self) -> String {
+        let error_buffer = self.runtime_error_buffer()
+            + NEW_LINE
+            + NEW_LINE
+            + self.compile_error_buffer().as_str();
+        if error_buffer.trim().is_empty() {
+            self.wrong_answer_buffer()
+        } else {
+            error_buffer
+        }
+    }
+
+    fn runtime_error_buffer(&self) -> String {
+        if !self.submission_response.has_runtime_error() {
+            return NEW_LINE.to_owned();
+        }
+        self.submission_response.status_msg.to_owned()
+    }
+
+    fn compile_error_buffer(&self) -> String {
+        if !self.submission_response.has_compile_error() {
+            return NEW_LINE.to_owned();
+        }
+        self.submission_response
+            .full_compile_error
+            .to_owned()
+            .unwrap_or_default()
+    }
+
+    fn wrong_answer_buffer(&self) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&bold_text(
+            &Color::Red(&format!(
+                "\n{} Wrong Answer: ({})\n\n",
+                Icon::_No.to_string(),
+                self.total_cases_ratio_buffer(&self.submission_response)
+            ))
+            .make(),
+        ));
+        buffer.push_str(&self.last_test_case_buffer());
+        buffer.push_str(&Color::Red(&self.get_metas()).make());
+
+        buffer
+    }
+
+    fn last_test_case_buffer(&self) -> String {
+        let mut buffer = String::new();
+        match (
+            &self.submission_response.input,
+            &self.submission_response.code_output,
+            &self.submission_response.expected_output,
+        ) {
+            (
+                Some(Either::String(input)),
+                Some(Either::String(ans)),
+                Some(Either::String(exp_ans)),
+            ) => {
+                let mut test_case = String::new();
+                test_case.push_str(&Color::Red("Last test case:\n").make());
+                test_case.push_str(&format!(
+                    "\tInput: \n\t\t{}\n",
+                    input.replace('\n', "\n\t\t")
+                ));
+                test_case.push_str(&format!("\n\tOutput: {}\n", ans));
+                test_case.push_str(&format!("\tExpected: {}\n\n", exp_ans));
+
+                buffer.push_str(test_case.as_str());
+            }
+            _ => {}
+        }
+
+        buffer
+    }
+
+    fn success_buffer(&self) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&bold_text(
+            &Color::Green(&format!(
+                "{} Accepted: ({})\n\n",
+                Icon::Yes.to_string(),
+                self.total_cases_ratio_buffer(&self.submission_response)
+            ))
+            .make(),
+        ));
+        buffer.push_str(&self.last_test_case_buffer());
+        buffer.push_str(&Color::Green(&self.get_metas()).make());
+
+        buffer
+    }
+
+    fn get_metas(&self) -> String {
+        if self.is_error() {
+            return NEW_LINE.to_string();
+        }
+        let memory_percentile = self
+            .submission_response
+            .memory_percentile
+            .unwrap_or(0.0)
+            .to_string();
+        let runtime_percentile = self
+            .submission_response
+            .runtime_percentile
+            .unwrap_or(0.0)
+            .to_string();
+        let metas = vec![
+            "Memory: ".to_string() + self.submission_response.status_memory.as_str(),
+            "Memory %ile: ".to_string() + memory_percentile.as_str(),
+            "Runtime: ".to_string() + self.submission_response.status_runtime.as_str(),
+            "Runtime %ile: ".to_string() + runtime_percentile.as_str(),
+            "\n\n".to_string(),
+        ];
+
+        metas.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Printer, SubmitExecutionResult};
+    use crate::model::SubmissionResponse;
+    use serde_json::from_value;
+
+    #[test]
+    fn print_submit_wrong_answer() {
+        let json_value = serde_json::from_str(
+            r#"{
+	"status_code": 11,
+	"lang": "python3",
+	"run_success": true,
+	"status_runtime": "N/A",
+	"memory": 16468000,
+	"question_id": "10",
+	"elapsed_time": 65,
+	"compare_result": "1110011111111111100011110100100011010111111111111111111101110111111111111111111111110111111110100111010111111111111111011101111111110011111111111111111110101101110010111011011101111101111111110111101011101111101111111111111101101110110111101110011111101001111110110110101101110011001111111111111111001110000010110111111111111110111110111110011111001001010",
+	"code_output": "false",
+	"std_output": "",
+	"last_testcase": "\"aab\"\n\"c*a*b\"",
+	"expected_output": "true",
+	"task_finish_time": 1694277425292,
+	"task_name": "judger.judgetask.Judge",
+	"finished": true,
+	"total_correct": 277,
+	"total_testcases": 355,
+	"runtime_percentile": null,
+	"status_memory": "N/A",
+	"memory_percentile": null,
+	"pretty_lang": "Python3",
+	"submission_id": "1044868319",
+	"input_formatted": "\"aab\", \"c*a*b\"",
+	"input": "\"aab\"\n\"c*a*b\"",
+	"status_msg": "Wrong Answer",
+	"state": "SUCCESS"
+}"#
+                    )
+        .unwrap();
+
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
+
+        let result = SubmitExecutionResult::new(response);
+        result.print();
+        // TODO implement snapshot testing
+        assert!(1 == 1);
+    }
+
+    #[test]
+    fn print_submit_accepted() {
+        let json_value = serde_json::from_str(
+            r#"{
+	"status_code": 10,
+	"lang": "rust",
+	"run_success": true,
+	"status_runtime": "0 ms",
+	"memory": 1928000,
+	"question_id": "10",
+	"elapsed_time": 10,
+	"compare_result": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+	"code_output": "",
+	"std_output": "",
+	"last_testcase": "",
+	"expected_output": "",
+	"task_finish_time": 1694280355711,
+	"task_name": "judger.judgetask.Judge",
+	"finished": true,
+	"total_correct": 355,
+	"total_testcases": 355,
+	"runtime_percentile": 100,
+	"status_memory": "1.9 MB",
+	"memory_percentile": 91.83670000000001,
+	"pretty_lang": "Rust",
+	"submission_id": "1044907055",
+	"status_msg": "Accepted",
+	"state": "SUCCESS"
+}"#
+        )
+        .unwrap();
+
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
+
+        let result = SubmitExecutionResult::new(response);
+        result.print();
+        // TODO implement snapshot testing
+        assert!(1 == 1);
+    }
+
+    #[test]
+    fn print_submit_wrong_answer_seq() {
+        let json_value = serde_json::from_str(
+r#"{
+	"status_code": 11,
+	"lang": "java",
+	"run_success": true,
+	"status_runtime": "N/A",
+	"memory": 44740000,
+	"display_runtime": "261",
+	"question_id": "15",
+	"elapsed_time": 467,
+	"compare_result": "111111111111111111110010011100110000111100001101000100000010111101100110011101001001000000010101101000000000000001111100001000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100",
+	"code_output": "[[-2,-1,3],[-2,0,2]]",
+	"std_output": "",
+	"last_testcase": "[3,0,-2,-1,1,2]",
+	"expected_output": "[[-2,-1,3],[-2,0,2],[-1,0,1]]",
+	"task_finish_time": 1694280912080,
+	"task_name": "judger.judgetask.Judge",
+	"finished": true,
+	"total_correct": 63,
+	"total_testcases": 312,
+	"runtime_percentile": null,
+	"status_memory": "N/A",
+	"memory_percentile": null,
+	"pretty_lang": "Java",
+	"submission_id": "1044914848",
+	"input_formatted": "[3,0,-2,-1,1,2]",
+	"input": "[3,0,-2,-1,1,2]",
+	"status_msg": "Wrong Answer",
+	"state": "SUCCESS"
+}"#
+        )
+        .unwrap();
+
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
+
+        let result = SubmitExecutionResult::new(response);
+        result.print();
+        // TODO implement snapshot testing
+        assert!(1 == 1);
+    }
+}

--- a/src/printer/test_execution_printer.rs
+++ b/src/printer/test_execution_printer.rs
@@ -11,6 +11,22 @@ pub struct TestExecutionResult {
 
 impl Printer for TestExecutionResult {}
 
+impl ExecutionResultPrinter for TestExecutionResult {
+    fn is_error(&self) -> bool {
+        self.submission_result.has_compile_error()
+            || self.submission_result.has_runtime_error()
+            || self.submission_result.has_error()
+    }
+
+    fn buffer(&self) -> String {
+        if self.is_error() {
+            self.error_buffer()
+        } else {
+            self.success_buffer()
+        }
+    }
+}
+
 impl TestExecutionResult {
     pub fn new(test_data: Either, submission_result: SubmissionResult) -> Self {
         Self {
@@ -20,23 +36,25 @@ impl TestExecutionResult {
     }
 
     fn error_buffer(&self) -> String {
-        let error_buffer =
-            self.get_runtime_error() + NEW_LINE + NEW_LINE + self.get_compile_error().as_str();
+        let error_buffer = self.runtime_error_buffer()
+            + NEW_LINE
+            + NEW_LINE
+            + self.compile_error_buffer().as_str();
         if error_buffer.trim().is_empty() {
-            self.get_wrong_answer()
+            self.wrong_answer_buffer()
         } else {
             error_buffer
         }
     }
 
-    fn get_runtime_error(&self) -> String {
+    fn runtime_error_buffer(&self) -> String {
         if !self.submission_result.has_runtime_error() {
             return NEW_LINE.to_owned();
         }
         self.submission_result.status_msg.to_owned()
     }
 
-    fn get_compile_error(&self) -> String {
+    fn compile_error_buffer(&self) -> String {
         if !self.submission_result.has_compile_error() {
             return NEW_LINE.to_owned();
         }
@@ -46,7 +64,7 @@ impl TestExecutionResult {
             .unwrap_or_default()
     }
 
-    fn get_wrong_answer(&self) -> String {
+    fn wrong_answer_buffer(&self) -> String {
         let mut buffer = String::new();
         buffer.push_str(&self.bold_text(
             &Color::Red(&format!("\n{} Wrong Answer:\n\n", Icon::_No.to_string())).make(),
@@ -94,7 +112,7 @@ impl TestExecutionResult {
         buffer
     }
 
-    fn success(&self) -> String {
+    fn success_buffer(&self) -> String {
         let mut buffer = String::new();
         buffer.push_str(
             &self.bold_text(
@@ -138,22 +156,6 @@ impl TestExecutionResult {
         ];
 
         metas.join("\n")
-    }
-}
-
-impl ExecutionResultPrinter for TestExecutionResult {
-    fn is_error(&self) -> bool {
-        self.submission_result.has_compile_error()
-            || self.submission_result.has_runtime_error()
-            || self.submission_result.has_error()
-    }
-
-    fn buffer(&self) -> String {
-        if self.is_error() {
-            self.error_buffer()
-        } else {
-            self.success()
-        }
     }
 }
 

--- a/src/printer/test_execution_printer.rs
+++ b/src/printer/test_execution_printer.rs
@@ -1,6 +1,6 @@
 use colci::Color;
 
-use crate::printer::{ExecutionResultPrinter, Printer, NEW_LINE};
+use crate::printer::{decorator::bold_text, ExecutionResultPrinter, Printer, NEW_LINE};
 use crate::{icon::Icon, model::SubmissionResult, Either};
 
 #[derive(Debug)]
@@ -66,7 +66,7 @@ impl TestExecutionResult {
 
     fn wrong_answer_buffer(&self) -> String {
         let mut buffer = String::new();
-        buffer.push_str(&self.bold_text(
+        buffer.push_str(&bold_text(
             &Color::Red(&format!("\n{} Wrong Answer:\n\n", Icon::_No.to_string())).make(),
         ));
         buffer.push_str(&self.test_cases_buffer());
@@ -114,11 +114,9 @@ impl TestExecutionResult {
 
     fn success_buffer(&self) -> String {
         let mut buffer = String::new();
-        buffer.push_str(
-            &self.bold_text(
-                &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
-            ),
-        );
+        buffer.push_str(&bold_text(
+            &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
+        ));
         buffer.push_str(&self.test_cases_buffer());
         buffer.push_str(&Color::Green(&self.get_metas()).make());
 

--- a/src/printer/test_execution_printer.rs
+++ b/src/printer/test_execution_printer.rs
@@ -1,23 +1,7 @@
 use colci::Color;
-use log::debug;
 
+use crate::printer::{ExecutionResultPrinter, Printer, NEW_LINE};
 use crate::{icon::Icon, model::SubmissionResult, Either};
-
-const NEW_LINE: &'static str = "\n";
-const TEXT_BOLD_ON: &'static str = "\x1b[1m";
-const TEXT_BOLD_OFF: &'static str = "\x1b[m";
-
-pub trait Printer: ExecutionResultPrinter {
-    fn print(&self) {
-        print!("{}", self.buffer());
-    }
-}
-
-pub trait ExecutionResultPrinter {
-    fn is_error(&self) -> bool;
-
-    fn buffer(&self) -> String;
-}
 
 #[derive(Debug)]
 pub struct TestExecutionResult {
@@ -64,7 +48,7 @@ impl TestExecutionResult {
 
     fn get_wrong_answer(&self) -> String {
         let mut buffer = String::new();
-        buffer.push_str(&bold_text(
+        buffer.push_str(&self.bold_text(
             &Color::Red(&format!("\n{} Wrong Answer:\n\n", Icon::_No.to_string())).make(),
         ));
         buffer.push_str(&self.test_cases_buffer());
@@ -112,9 +96,11 @@ impl TestExecutionResult {
 
     fn success(&self) -> String {
         let mut buffer = String::new();
-        buffer.push_str(&bold_text(
-            &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
-        ));
+        buffer.push_str(
+            &self.bold_text(
+                &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
+            ),
+        );
         buffer.push_str(&self.test_cases_buffer());
         buffer.push_str(&Color::Green(&self.get_metas()).make());
 
@@ -171,12 +157,8 @@ impl ExecutionResultPrinter for TestExecutionResult {
     }
 }
 
-fn bold_text(s: &str) -> String {
-    format!("{}{}{}", s, TEXT_BOLD_ON, TEXT_BOLD_OFF)
-}
-
 #[cfg(test)]
-mod printer {
+mod tests {
     use super::{Printer, TestExecutionResult};
     use crate::{model::SubmissionResult, Either};
     use serde_json::from_value;

--- a/src/printer/test_execution_printer.rs
+++ b/src/printer/test_execution_printer.rs
@@ -1,21 +1,18 @@
 use colci::Color;
 
-use crate::printer::{decorator::bold_text, ExecutionResultPrinter, Printer, NEW_LINE};
-use crate::{icon::Icon, model::SubmissionResult, Either};
+use crate::model::ExecutionErrorResponse;
+use crate::printer::{decorator::bold_text, Printer, NEW_LINE};
+use crate::{icon::Icon, model::SubmissionResponse, Either};
 
 #[derive(Debug)]
 pub struct TestExecutionResult {
     test_data: Either,
-    submission_result: SubmissionResult,
+    submission_response: SubmissionResponse,
 }
 
-impl Printer for TestExecutionResult {}
-
-impl ExecutionResultPrinter for TestExecutionResult {
+impl Printer for TestExecutionResult {
     fn is_error(&self) -> bool {
-        self.submission_result.has_compile_error()
-            || self.submission_result.has_runtime_error()
-            || self.submission_result.has_error()
+        self.submission_response.is_error()
     }
 
     fn buffer(&self) -> String {
@@ -28,10 +25,10 @@ impl ExecutionResultPrinter for TestExecutionResult {
 }
 
 impl TestExecutionResult {
-    pub fn new(test_data: Either, submission_result: SubmissionResult) -> Self {
+    pub fn new(test_data: Either, submission_result: SubmissionResponse) -> Self {
         Self {
             test_data,
-            submission_result,
+            submission_response: submission_result,
         }
     }
 
@@ -48,17 +45,17 @@ impl TestExecutionResult {
     }
 
     fn runtime_error_buffer(&self) -> String {
-        if !self.submission_result.has_runtime_error() {
+        if !self.submission_response.has_runtime_error() {
             return NEW_LINE.to_owned();
         }
-        self.submission_result.status_msg.to_owned()
+        self.submission_response.status_msg.to_owned()
     }
 
     fn compile_error_buffer(&self) -> String {
-        if !self.submission_result.has_compile_error() {
+        if !self.submission_response.has_compile_error() {
             return NEW_LINE.to_owned();
         }
-        self.submission_result
+        self.submission_response
             .full_compile_error
             .to_owned()
             .unwrap_or_default()
@@ -67,7 +64,12 @@ impl TestExecutionResult {
     fn wrong_answer_buffer(&self) -> String {
         let mut buffer = String::new();
         buffer.push_str(&bold_text(
-            &Color::Red(&format!("\n{} Wrong Answer:\n\n", Icon::_No.to_string())).make(),
+            &Color::Red(&format!(
+                "\n{} Wrong Answer: ({})\n\n",
+                Icon::_No.to_string(),
+                self.total_cases_ratio_buffer(&self.submission_response)
+            ))
+            .make(),
         ));
         buffer.push_str(&self.test_cases_buffer());
         buffer.push_str(&Color::Red(&self.get_metas()).make());
@@ -80,16 +82,24 @@ impl TestExecutionResult {
         // combine test_data, code_answer & expected_code_answer
         match (
             &self.test_data,
-            &self.submission_result.code_answer,
-            &self.submission_result.expected_code_answer,
+            &self.submission_response.code_answer,
+            &self.submission_response.expected_code_answer,
         ) {
             (
                 Either::Sequence(input_seq),
                 Some(Either::Sequence(ans_seq)),
                 Some(Either::Sequence(exp_ans_seq)),
             ) => {
-                for (i, ((input, ans), exp_ans)) in
-                    input_seq.iter().zip(ans_seq).zip(exp_ans_seq).enumerate()
+                let chunk_size = input_seq.len() / ans_seq.len();
+                let input_chunks: Vec<Vec<String>> = input_seq
+                    .chunks(chunk_size)
+                    .map(|chunk| chunk.to_vec())
+                    .collect();
+                for (i, ((input, ans), exp_ans)) in input_chunks
+                    .iter()
+                    .zip(ans_seq)
+                    .zip(exp_ans_seq)
+                    .enumerate()
                 {
                     let mut test_case = String::new();
                     let is_correct = ans.eq(exp_ans);
@@ -99,8 +109,8 @@ impl TestExecutionResult {
                         Color::Red(&format!("{} Case {}:\n", Icon::_No.to_string(), i + 1)).make()
                     };
                     test_case.push_str(&colored_case);
-                    test_case.push_str(&format!("\tInput: {}\n", input));
-                    test_case.push_str(&format!("\tOutput: {}\n", ans));
+                    test_case.push_str(&format!("\tInput: \n\t\t{}\n", input.join("\n\t\t")));
+                    test_case.push_str(&format!("\n\tOutput: {}\n", ans));
                     test_case.push_str(&format!("\tExpected: {}\n\n", exp_ans));
 
                     buffer.push_str(test_case.as_str());
@@ -115,7 +125,12 @@ impl TestExecutionResult {
     fn success_buffer(&self) -> String {
         let mut buffer = String::new();
         buffer.push_str(&bold_text(
-            &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
+            &Color::Green(&format!(
+                "{} Accepted: ({})\n\n",
+                Icon::Yes.to_string(),
+                self.total_cases_ratio_buffer(&self.submission_response)
+            ))
+            .make(),
         ));
         buffer.push_str(&self.test_cases_buffer());
         buffer.push_str(&Color::Green(&self.get_metas()).make());
@@ -125,30 +140,30 @@ impl TestExecutionResult {
 
     fn get_metas(&self) -> String {
         let memory_percentile = self
-            .submission_result
+            .submission_response
             .memory_percentile
             .unwrap_or(0.0)
             .to_string();
         let runtime_percentile = self
-            .submission_result
+            .submission_response
             .runtime_percentile
             .unwrap_or(0.0)
             .to_string();
         let testcases = format!(
             "{}/{}",
-            self.submission_result.total_correct.unwrap_or(0),
-            self.submission_result.total_testcases.unwrap_or(0)
+            self.submission_response.total_correct.unwrap_or(0),
+            self.submission_response.total_testcases.unwrap_or(0)
         );
         let accepted_meta = format!(
             "{}: ({})",
-            self.submission_result.status_msg.as_str(),
+            self.submission_response.status_msg.as_str(),
             testcases.as_str()
         );
         let metas = vec![
             accepted_meta,
-            "Memory: ".to_string() + self.submission_result.status_memory.as_str(),
+            "Memory: ".to_string() + self.submission_response.status_memory.as_str(),
             "Memory %ile: ".to_string() + memory_percentile.as_str(),
-            "Runtime: ".to_string() + self.submission_result.status_runtime.as_str(),
+            "Runtime: ".to_string() + self.submission_response.status_runtime.as_str(),
             "Runtime %ile: ".to_string() + runtime_percentile.as_str(),
             "\n\n".to_string(),
         ];
@@ -160,7 +175,7 @@ impl TestExecutionResult {
 #[cfg(test)]
 mod tests {
     use super::{Printer, TestExecutionResult};
-    use crate::{model::SubmissionResult, Either};
+    use crate::{model::SubmissionResponse, Either};
     use serde_json::from_value;
 
     #[test]
@@ -243,10 +258,11 @@ mod tests {
         )
         .unwrap();
 
-        let response = from_value::<SubmissionResult>(json_value).unwrap().into();
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
 
         let result = TestExecutionResult::new(test_data, response);
         result.print();
+        // TODO implement snapshot testing
         assert!(1 == 1);
     }
 
@@ -330,10 +346,57 @@ mod tests {
         )
         .unwrap();
 
-        let response = from_value::<SubmissionResult>(json_value).unwrap().into();
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
 
         let result = TestExecutionResult::new(test_data, response);
         result.print();
+        // TODO implement snapshot testing
+        assert!(1 == 1);
+    }
+
+    #[test]
+    fn print_multi_input_accepted() {
+        let test_data = Either::Sequence(vec![
+            "aa".to_owned(),
+            "a".to_owned(),
+            "aa".to_owned(),
+            "a*".to_owned(),
+            "ab".to_owned(),
+            ".*".to_owned(),
+        ]);
+        let json_value = serde_json::from_str(
+r#"{"status_code": 10, "lang": "rust", "run_success": true, "status_runtime": "0 ms", "memory": 2096000, "code_answer": ["false", "true", "true"], "code_output": [], "std_output_list": ["", "", "", ""], "elapsed_time": 39, "task_finish_time": 1694281117287, "task_name": "judger.runcodetask.RunCode", "expected_status_code": 10, "expected_lang": "cpp", "expected_run_success": true, "expected_status_runtime": "0", "expected_memory": 5936000, "expected_code_answer": ["false", "true", "true"], "expected_code_output": [], "expected_std_output_list": ["", "", "", ""], "expected_elapsed_time": 37, "expected_task_finish_time": 1694281041897, "expected_task_name": "judger.interprettask.Interpret", "correct_answer": true, "compare_result": "111", "total_correct": 3, "total_testcases": 3, "runtime_percentile": null, "status_memory": "2.1 MB", "memory_percentile": null, "pretty_lang": "Rust", "submission_id": "runcode_1694281112.034828_DfKA6OnxO1", "status_msg": "Accepted", "state": "SUCCESS"}"#
+        )
+        .unwrap();
+
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
+
+        let result = TestExecutionResult::new(test_data, response);
+        result.print();
+        // TODO implement snapshot testing
+        assert!(1 == 1);
+    }
+
+    #[test]
+    fn print_multi_input_wrong_answer() {
+        let test_data = Either::Sequence(vec![
+            "aa".to_owned(),
+            "a".to_owned(),
+            "aa".to_owned(),
+            "a*".to_owned(),
+            "ab".to_owned(),
+            ".*".to_owned(),
+        ]);
+        let json_value = serde_json::from_str(
+            r#"{"status_code": 10, "lang": "rust", "run_success": true, "status_runtime": "1 ms", "memory": 2000000, "code_answer": ["false", "false", "false"], "code_output": [], "std_output_list": ["", "", "", ""], "elapsed_time": 16, "task_finish_time": 1694281884439, "task_name": "judger.runcodetask.RunCode", "expected_status_code": 10, "expected_lang": "cpp", "expected_run_success": true, "expected_status_runtime": "0", "expected_memory": 5936000, "expected_code_answer": ["false", "true", "true"], "expected_code_output": [], "expected_std_output_list": ["", "", "", ""], "expected_elapsed_time": 37, "expected_task_finish_time": 1694281041897, "expected_task_name": "judger.interprettask.Interpret", "correct_answer": false, "compare_result": "100", "total_correct": 1, "total_testcases": 3, "runtime_percentile": null, "status_memory": "2 MB", "memory_percentile": null, "pretty_lang": "Rust", "submission_id": "runcode_1694281880.8477898_KECPBvM8Vm", "status_msg": "Accepted", "state": "SUCCESS"}"#
+        )
+        .unwrap();
+
+        let response = from_value::<SubmissionResponse>(json_value).unwrap().into();
+
+        let result = TestExecutionResult::new(test_data, response);
+        result.print();
+        // TODO implement snapshot testing
         assert!(1 == 1);
     }
 }

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -259,7 +259,7 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
             .urls
             .verify
             .replace("$id", &response["submission_id"].to_string());
-        let result: SubmissionResult = serde_json::from_value(self.verify_run_code(&url).await?)?;
+        let _result: SubmissionResult = serde_json::from_value(self.verify_run_code(&url).await?)?;
         todo!("call print for submit")
     }
 

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -23,11 +23,8 @@ use crate::template::parse_code;
 use crate::{
     client::RemoteClient,
     cmd::{self, List, OrderBy, Query, User},
-    service::{
-        self, auth,
-        result_printer::{Printer, TestExecutionResult},
-        CacheKey, Comment, CommentStyle, LangInfo, ServiceProvider, Session,
-    },
+    printer::{Printer, TestExecutionResult},
+    service::{self, auth, CacheKey, Comment, CommentStyle, LangInfo, ServiceProvider, Session},
     template::{InjectPosition, Pattern},
     Config, Either, LeetUpError, Result,
 };

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -16,9 +16,10 @@ use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde_json::{json, Value};
 
 use crate::model::{
-    CodeDefinition, Problem, ProblemInfo, ProblemInfoSeq, StatStatusPair, SubmissionResult,
+    CodeDefinition, Problem, ProblemInfo, ProblemInfoSeq, StatStatusPair, SubmissionResponse,
     TopicTagQuestion,
 };
+use crate::printer::SubmitExecutionResult;
 use crate::template::parse_code;
 use crate::{
     client::RemoteClient,
@@ -232,9 +233,8 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
                         LeetUpError::Any(anyhow!("Unable to replace `interpret_id`"))
                     })?,
                 );
-                let result: SubmissionResult =
+                let result: SubmissionResponse =
                     serde_json::from_value(self.verify_run_code(&url).await?)?;
-                print!("\n");
                 let execution_result = TestExecutionResult::new(test_data.into(), result);
                 execution_result.print();
             }
@@ -259,8 +259,10 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
             .urls
             .verify
             .replace("$id", &response["submission_id"].to_string());
-        let _result: SubmissionResult = serde_json::from_value(self.verify_run_code(&url).await?)?;
-        todo!("call print for submit")
+        let result: SubmissionResponse = serde_json::from_value(self.verify_run_code(&url).await?)?;
+        let execution_result = SubmitExecutionResult::new(result);
+        execution_result.print();
+        Ok(())
     }
 
     async fn process_auth(&mut self, user: User) -> Result<()> {

--- a/src/service/leetcode.rs
+++ b/src/service/leetcode.rs
@@ -25,7 +25,7 @@ use crate::{
     cmd::{self, List, OrderBy, Query, User},
     service::{
         self, auth,
-        result_printer::{Printer, TestCaseResults},
+        result_printer::{Printer, TestExecutionResult},
         CacheKey, Comment, CommentStyle, LangInfo, ServiceProvider, Session,
     },
     template::{InjectPosition, Pattern},
@@ -237,7 +237,9 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
                 );
                 let result: SubmissionResult =
                     serde_json::from_value(self.verify_run_code(&url).await?)?;
-                self.print_judge_result(Some(test_data), result)?;
+                print!("\n");
+                let execution_result = TestExecutionResult::new(test_data.into(), result);
+                execution_result.print();
             }
         }
 
@@ -261,7 +263,7 @@ impl<'a> ServiceProvider<'a> for Leetcode<'a> {
             .verify
             .replace("$id", &response["submission_id"].to_string());
         let result: SubmissionResult = serde_json::from_value(self.verify_run_code(&url).await?)?;
-        self.print_judge_result(None, result)
+        todo!("call print for submit")
     }
 
     async fn process_auth(&mut self, user: User) -> Result<()> {
@@ -452,20 +454,6 @@ impl<'a> Leetcode<'a> {
 
         let mut file = File::create(&filename)?;
         file.write_all(content)?;
-        Ok(())
-    }
-
-    fn print_judge_result(
-        &self,
-        test_data: Option<String>,
-        result: SubmissionResult,
-    ) -> Result<()> {
-        println!(
-            "\n{}",
-            Color::Magenta(&format!("\nInput:\n{}", test_data.unwrap_or_default())).make()
-        );
-        let results: TestCaseResults = result.into();
-        results.print();
         Ok(())
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -10,5 +10,4 @@ mod lang;
 pub mod leetcode;
 mod pool;
 mod provider;
-mod result_printer;
 mod session;

--- a/src/service/result_printer.rs
+++ b/src/service/result_printer.rs
@@ -1,95 +1,127 @@
 use colci::Color;
-use log::info;
+use log::debug;
 
-use crate::{model::SubmissionResult, Either};
+use crate::{icon::Icon, model::SubmissionResult, Either};
 
-pub trait Printer {
-    /// Prints text
-    fn print(&self);
+const NEW_LINE: &'static str = "\n";
+const TEXT_BOLD_ON: &'static str = "\x1b[1m";
+const TEXT_BOLD_OFF: &'static str = "\x1b[m";
+
+pub trait Printer: ExecutionResultPrinter {
+    fn print(&self) {
+        print!("{}", self.buffer());
+    }
+}
+
+pub trait ExecutionResultPrinter {
+    fn is_error(&self) -> bool;
+
+    fn buffer(&self) -> String;
 }
 
 #[derive(Debug)]
-pub struct TestCaseResult {
-    answer: String,
-    expected_answer: String,
-    is_correct: bool,
-}
-
-impl TestCaseResult {
-    fn new(answer: String, expected_answer: String, is_correct: bool) -> Self {
-        Self {
-            answer,
-            expected_answer,
-            is_correct,
-        }
-    }
-}
-
-impl Printer for TestCaseResult {
-    fn print(&self) {
-        let text = format!(
-            "Answer: {}\nExpected Answer: {}",
-            self.answer, self.expected_answer
-        );
-        let colored_text = if self.is_correct {
-            Color::Green(&text).make()
-        } else {
-            Color::Red(&text).make()
-        };
-        println!("{}", colored_text);
-    }
-}
-
-pub struct TestCaseResults {
+pub struct TestExecutionResult {
+    test_data: Either,
     submission_result: SubmissionResult,
-    results: Vec<TestCaseResult>,
 }
 
-impl TestCaseResults {
-    fn new(submission_result: SubmissionResult, results: Vec<TestCaseResult>) -> Self {
+impl Printer for TestExecutionResult {}
+
+impl TestExecutionResult {
+    pub fn new(test_data: Either, submission_result: SubmissionResult) -> Self {
         Self {
+            test_data,
             submission_result,
-            results,
         }
     }
 
-    fn get_answers(left: Option<&Either>, right: Option<&Either>) -> Vec<(String, String)> {
-        match (left, right) {
-            (Some(Either::Sequence(vec1)), Some(Either::Sequence(vec2))) => {
-                let mut vec = vec2.clone();
-                if vec2.is_empty() {
-                    vec = std::iter::repeat("".to_string())
-                        .take(vec1.len())
-                        .collect::<Vec<_>>();
+    fn error_buffer(&self) -> String {
+        let error_buffer =
+            self.get_runtime_error() + NEW_LINE + NEW_LINE + self.get_compile_error().as_str();
+        if error_buffer.trim().is_empty() {
+            self.get_wrong_answer()
+        } else {
+            error_buffer
+        }
+    }
+
+    fn get_runtime_error(&self) -> String {
+        if !self.submission_result.has_runtime_error() {
+            return NEW_LINE.to_owned();
+        }
+        self.submission_result.status_msg.to_owned()
+    }
+
+    fn get_compile_error(&self) -> String {
+        if !self.submission_result.has_compile_error() {
+            return NEW_LINE.to_owned();
+        }
+        self.submission_result
+            .full_compile_error
+            .to_owned()
+            .unwrap_or_default()
+    }
+
+    fn get_wrong_answer(&self) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&bold_text(
+            &Color::Red(&format!("\n{} Wrong Answer:\n\n", Icon::_No.to_string())).make(),
+        ));
+        buffer.push_str(&self.test_cases_buffer());
+        buffer.push_str(&Color::Red(&self.get_metas()).make());
+
+        buffer
+    }
+
+    fn test_cases_buffer(&self) -> String {
+        let mut buffer = String::new();
+        // combine test_data, code_answer & expected_code_answer
+        match (
+            &self.test_data,
+            &self.submission_result.code_answer,
+            &self.submission_result.expected_code_answer,
+        ) {
+            (
+                Either::Sequence(input_seq),
+                Some(Either::Sequence(ans_seq)),
+                Some(Either::Sequence(exp_ans_seq)),
+            ) => {
+                for (i, ((input, ans), exp_ans)) in
+                    input_seq.iter().zip(ans_seq).zip(exp_ans_seq).enumerate()
+                {
+                    let mut test_case = String::new();
+                    let is_correct = ans.eq(exp_ans);
+                    let colored_case = if is_correct {
+                        Color::Green(&format!("{} Case {}:\n", Icon::Yes.to_string(), i + 1)).make()
+                    } else {
+                        Color::Red(&format!("{} Case {}:\n", Icon::_No.to_string(), i + 1)).make()
+                    };
+                    test_case.push_str(&colored_case);
+                    test_case.push_str(&format!("\tInput: {}\n", input));
+                    test_case.push_str(&format!("\tOutput: {}\n", ans));
+                    test_case.push_str(&format!("\tExpected: {}\n\n", exp_ans));
+
+                    buffer.push_str(test_case.as_str());
                 }
-                vec1.iter().cloned().zip(vec.iter().cloned()).collect()
             }
-            _ => vec![],
+            _ => {}
         }
+
+        buffer
     }
 
-    fn print_compile_error(&self) {
-        println!(
-            "{}",
-            Color::Red(
-                &self
-                    .submission_result
-                    .full_compile_error
-                    .to_owned()
-                    .unwrap_or_default()
-            )
-            .make()
-        );
+    fn success(&self) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&bold_text(
+            &Color::Green(&format!("{} Accepted:\n\n", Icon::Yes.to_string())).make(),
+        ));
+        buffer.push_str(&self.test_cases_buffer());
+        buffer.push_str(&Color::Green(&self.get_metas()).make());
+
+        buffer
     }
 
-    fn print_status_msg(&self) {
-        println!(
-            "{}",
-            Color::Red(self.submission_result.status_msg.as_str()).make()
-        );
-    }
-
-    fn print_submission_result(&self) {
+    fn get_metas(&self) -> String {
         let memory_percentile = self
             .submission_result
             .memory_percentile
@@ -116,72 +148,210 @@ impl TestCaseResults {
             "Memory %ile: ".to_string() + memory_percentile.as_str(),
             "Runtime: ".to_string() + self.submission_result.status_runtime.as_str(),
             "Runtime %ile: ".to_string() + runtime_percentile.as_str(),
+            "\n\n".to_string(),
         ];
-        for meta in metas {
-            println!("{}", Color::Green(meta.as_str()).make());
-        }
-    }
 
-    fn get_stdout(&self) -> String {
-        if let Some(Either::Sequence(o)) = self.submission_result.code_output.as_ref() {
-            return o.join("\n");
-        }
-
-        "".to_string()
+        metas.join("\n")
     }
 }
 
-impl Printer for TestCaseResults {
-    fn print(&self) {
-        if self.submission_result.has_compile_error() {
-            self.print_compile_error();
-            return;
+impl ExecutionResultPrinter for TestExecutionResult {
+    fn is_error(&self) -> bool {
+        self.submission_result.has_compile_error()
+            || self.submission_result.has_runtime_error()
+            || self.submission_result.has_error()
+    }
+
+    fn buffer(&self) -> String {
+        if self.is_error() {
+            self.error_buffer()
+        } else {
+            self.success()
         }
-
-        if !self.results.is_empty() {
-            for (i, test_case_result) in self.results.iter().enumerate() {
-                println!("\nTest {}/{}", i + 1, self.results.len());
-                test_case_result.print();
-            }
-
-            println!(
-                "\n{}\n{}",
-                Color::Yellow("Output:").make(),
-                Color::Magenta(&self.get_stdout()).make()
-            );
-            return;
-        }
-
-        if self.submission_result.has_runtime_error() || self.submission_result.has_error() {
-            self.print_status_msg();
-            return;
-        }
-
-        self.print_submission_result();
     }
 }
 
-impl From<SubmissionResult> for TestCaseResults {
-    fn from(submission_result: SubmissionResult) -> Self {
-        info!("submission result: {:#?}", submission_result);
+fn bold_text(s: &str) -> String {
+    format!("{}{}{}", s, TEXT_BOLD_ON, TEXT_BOLD_OFF)
+}
 
-        let answers = TestCaseResults::get_answers(
-            submission_result.code_answer.as_ref(),
-            submission_result.expected_code_answer.as_ref(),
-        );
+#[cfg(test)]
+mod printer {
+    use super::{Printer, TestExecutionResult};
+    use crate::{model::SubmissionResult, Either};
+    use serde_json::from_value;
 
-        let results = answers
-            .iter()
-            .map(|test_case_result| {
-                let (answer, expected_answer) = test_case_result;
-                TestCaseResult::new(
-                    answer.to_string(),
-                    expected_answer.to_string(),
-                    answer.eq(expected_answer),
-                )
-            })
-            .collect();
+    #[test]
+    fn print_sequence_success() {
+        let test_data = Either::Sequence(vec![
+            "[1,2,3]".to_owned(),
+            "[1,0,-1,-1,-1,1,0,1]".to_owned(),
+            "[1,0,-1]".to_owned(),
+            "[-1,0,1,2,-1,-4]".to_owned(),
+            "[0,1,1]".to_owned(),
+            "[0,0,0]".to_owned(),
+        ]);
+        let json_value = serde_json::from_str(
+            r#"{
+	"status_code": 10,
+	"lang": "java",
+	"run_success": true,
+	"status_runtime": "3 ms",
+	"memory": 40404000,
+	"display_runtime": "3",
+	"code_answer": [
+		"[]",
+		"[[-1,0,1]]",
+		"[[-1,0,1]]",
+		"[[-1,-1,2],[-1,0,1]]",
+		"[]",
+		"[[0,0,0]]"
+	],
+	"code_output": [],
+	"std_output_list": [
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		""
+	],
+	"elapsed_time": 217,
+	"task_finish_time": 1693886584999,
+	"task_name": "judger.runcodetask.RunCode",
+	"expected_status_code": 10,
+	"expected_lang": "cpp",
+	"expected_run_success": true,
+	"expected_status_runtime": "0",
+	"expected_memory": 6304000,
+	"expected_code_answer": [
+		"[]",
+		"[[-1,0,1]]",
+		"[[-1,0,1]]",
+		"[[-1,-1,2],[-1,0,1]]",
+		"[]",
+		"[[0,0,0]]"
+	],
+	"expected_code_output": [],
+	"expected_std_output_list": [
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		""
+	],
+	"expected_elapsed_time": 21,
+	"expected_task_finish_time": 1693885714905,
+	"expected_task_name": "judger.interprettask.Interpret",
+	"correct_answer": true,
+	"compare_result": "111111",
+	"total_correct": 6,
+	"total_testcases": 6,
+	"runtime_percentile": null,
+	"status_memory": "40.4 MB",
+	"memory_percentile": null,
+	"pretty_lang": "Java",
+	"submission_id": "runcode_1693886582.3348386_GUkqbCdnmN",
+	"status_msg": "Accepted",
+	"state": "SUCCESS"
+}"#,
+        )
+        .unwrap();
 
-        TestCaseResults::new(submission_result, results)
+        let response = from_value::<SubmissionResult>(json_value).unwrap().into();
+
+        let result = TestExecutionResult::new(test_data, response);
+        result.print();
+        assert!(1 == 1);
+    }
+
+    #[test]
+    fn print_sequence_wrong_answer() {
+        let test_data = Either::Sequence(vec![
+            "[1,2,3]".to_owned(),
+            "[1,0,-1,-1,-1,1,0,1]".to_owned(),
+            "[1,0,-1]".to_owned(),
+            "[-1,0,1,2,-1,-4]".to_owned(),
+            "[0,1,1]".to_owned(),
+            "[0,0,0]".to_owned(),
+        ]);
+        let json_value = serde_json::from_str(
+            r#"{
+	"status_code": 10,
+	"lang": "java",
+	"run_success": true,
+	"status_runtime": "2 ms",
+	"memory": 40560000,
+	"display_runtime": "2",
+	"code_answer": [
+		"[]",
+		"[[-1,0,1]]",
+		"[[-1,0,1]]",
+		"[[-1,-1,2]]",
+		"[]",
+		"[[0,0,0]]"
+	],
+	"code_output": [],
+	"std_output_list": [
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		""
+	],
+	"elapsed_time": 229,
+	"task_finish_time": 1693885714946,
+	"task_name": "judger.runcodetask.RunCode",
+	"expected_status_code": 10,
+	"expected_lang": "cpp",
+	"expected_run_success": true,
+	"expected_status_runtime": "0",
+	"expected_memory": 6304000,
+	"expected_code_answer": [
+		"[]",
+		"[[-1,0,1]]",
+		"[[-1,0,1]]",
+		"[[-1,-1,2],[-1,0,1]]",
+		"[]",
+		"[[0,0,0]]"
+	],
+	"expected_code_output": [],
+	"expected_std_output_list": [
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		""
+	],
+	"expected_elapsed_time": 21,
+	"expected_task_finish_time": 1693885714905,
+	"expected_task_name": "judger.interprettask.Interpret",
+	"correct_answer": false,
+	"compare_result": "111011",
+	"total_correct": 5,
+	"total_testcases": 6,
+	"runtime_percentile": null,
+	"status_memory": "40.6 MB",
+	"memory_percentile": null,
+	"pretty_lang": "Java",
+	"submission_id": "runcode_1693885710.9158015_9uDhRiWjFV",
+	"status_msg": "Accepted",
+	"state": "SUCCESS"
+}"#,
+        )
+        .unwrap();
+
+        let response = from_value::<SubmissionResult>(json_value).unwrap().into();
+
+        let result = TestExecutionResult::new(test_data, response);
+        result.print();
+        assert!(1 == 1);
     }
 }


### PR DESCRIPTION
- [x] Properly print execution result on test run:
    - [x] Runtime error
    - [x] Compile error
    - [x] Wrong answer 
- [x] Properly print execution result on submitting a problem:
    - [x] Runtime error
    - [x] Compile error
    - [x] Wrong answer 
<img width="351" alt="Screenshot 2023-09-04 at 9 36 39 PM" src="https://github.com/dragfire/leetup/assets/6277978/01f571dd-4e33-4599-9fdb-31d6fe5e5e86">
<img width="372" alt="Screenshot 2023-09-04 at 9 36 27 PM" src="https://github.com/dragfire/leetup/assets/6277978/793268e1-8dda-4bc9-926c-504845a9603c">
